### PR TITLE
[#13] 유저 목록 상단 부분 구현

### DIFF
--- a/client/src/components/feature/UserGridTable/index.tsx
+++ b/client/src/components/feature/UserGridTable/index.tsx
@@ -8,13 +8,12 @@ import { nameMasker, phoneNumberMasker, dateISOStringToFullDay, genderCodeToGend
 type Props = {
   tableHeadTrs: string[],
   tableBodyList: UserResponseDTO[] | undefined,
-  gridCols: string;
 }
 
 const UserGridTable = (props: Props) => {
 	return (
 		<ul
-			className={`grid grid-cols-${props.gridCols}`}
+			className={`grid grid-cols-[minmax(150px,_1fr)_minmax(120px,_1fr)_minmax(150px,_1fr)_minmax(200px,_1fr)_minmax(150px,_1fr)_minmax(180px,_1fr)_minmax(150px,_1fr)_minmax(150px,_1fr)_minmax(120px,_1fr)_minmax(150px,_1fr)_minmax(120px,_1fr)]`}
 		>
 			{isValidArray(props.tableHeadTrs) &&
 				props.tableHeadTrs?.map((tableHeadTr, index) => {

--- a/client/src/components/shared/DropDown/index.tsx
+++ b/client/src/components/shared/DropDown/index.tsx
@@ -1,11 +1,19 @@
-const DropDown = ({ list }: any) => {
+type Props = {
+	options: Array<{ value: string | number, renderText: string }>
+}
+
+const DropDown = (props: Props) => {
 	return (
 		<select
-			className="w-36 h-10 px-3 mx-2 border-solid border rounded outline-none"
+			className="w-36 h-10 px-3 mx-2 border-solid border rounded outline-none appearance-none bg-no-repeat bg-[url('https://www.svgrepo.com/show/80156/down-arrow.svg')] bg-[length:10px_10px] bg-[center_right_1rem]"
 			onChange={(e) => console.log(e.target.value)}
 		>
-			{list.map((item: any) => {
-				return <option value={item}>{item}</option>;
+			{props.options.map((option: { value: string | number; renderText: string }) => {
+				return (
+					<option key={option.renderText} value={option.value}>
+						{option.renderText}
+					</option>
+				);
 			})}
 		</select>
 	);

--- a/client/src/components/shared/SearchInput/index.tsx
+++ b/client/src/components/shared/SearchInput/index.tsx
@@ -1,8 +1,27 @@
-const SearchInput = () => {
+import React, { useRef } from 'react';
+
+type Props = {
+	onSearchByKeyword: (keyword: string) => void;
+};
+
+const SearchInput = (props: Props) => {
+	const searchInputRef = useRef() as React.MutableRefObject<HTMLInputElement>
+
+	const handleSearchFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		props.onSearchByKeyword(searchInputRef?.current?.value);
+	}
+
 	return (
-		<form className="flex items-center">
-			<input placeholder="검색어를 입력하세요." className="h-10 w-48 px-4 mr-1 border-solid border rounded  outline-none" />
-			<button className="h-10 w-12 rounded bg-[#041527] text-white font-bold">검색</button>
+		<form className="flex items-center" onSubmit={handleSearchFormSubmit}>
+			<input
+				ref={searchInputRef}
+				placeholder="검색어를 입력하세요."
+				className="h-10 w-48 px-4 mr-1 border-solid border rounded  outline-none"
+			/>
+			<button type="submit" className="h-10 w-12 rounded bg-[#041527] text-white font-bold opacity-80 hover:opacity-100">
+				검색
+			</button>
 		</form>
 	);
 };

--- a/client/src/core/apis/user.ts
+++ b/client/src/core/apis/user.ts
@@ -2,14 +2,14 @@ import { API_PATH, httpMehthod } from '@src/core/apis/common';
 import requester from '@src/core/apis/requester';
 import { UserResponseDTO } from '@src/types/api';
 
-export const getUsers = async () => {
+export const getUsers = async (query: string | null) => {
 	const {
 		user: { users },
 	} = API_PATH;
 
 	const { headers, status, payload } = await requester<UserResponseDTO[]>({
 		method: httpMehthod.GET,
-		url: `${users}`,
+		url: `${users}${query ? `?q=${query}` : ''}`,
 	});
 
 	return payload;

--- a/client/src/pages/BankAccount/index.tsx
+++ b/client/src/pages/BankAccount/index.tsx
@@ -11,16 +11,20 @@ const BankAccount = () => {
 		});
 	}, []);
 
+	const handleSearchByKeyword = (keyword: string) => {
+		
+	};
+
 	return (
 		<Layout>
 			<main className="p-8">
 				<div className="flex justify-between ">
 					<div>
-						<DropDown list={BROKER} />
-						<DropDown list={ACTIVATION} />
-						<DropDown list={STATUS} />
+						<DropDown options={BROKER} />
+						<DropDown options={ACTIVATION} />
+						<DropDown options={STATUS} />
 					</div>
-					<SearchInput />
+					<SearchInput onSearchByKeyword={handleSearchByKeyword} />
 				</div>
 				<AccountGrid accountList={accountList} />
 			</main>
@@ -31,33 +35,44 @@ const BankAccount = () => {
 export default BankAccount;
 
 const BROKER = [
-	'브로커명',
-	'유안타증권',
-	'현대증권',
-	'미래에셋증권',
-	'대우증권',
-	'삼성증권',
-	'한국투자증권',
-	'우리투자증권',
-	'교보증권',
-	'하이투자증권',
-	'HMC투자증권',
-	'키움증권',
-	'이베스트투자증권',
-	'SK증권',
-	'대신증권',
-	'아이엠투자증권',
-	'한화투자증권',
-	'하나대투자증권',
-	'동부증권',
-	'유진투자증권',
-	'카카오페이증권',
-	'메리츠종합금융증권',
-	'부국증권',
-	'신영증권',
-	'LIG투자증권',
-	'토스증권',
+	{ value: '000', renderText: '브로커명' },
+	{ value: '209', renderText: '유안타증권' },
+	{ value: '218', renderText: '현대증권' },
+	{ value: '230', renderText: '미래에셋증권' },
+	{ value: '238', renderText: '대우증권' },
+	{ value: '240', renderText: '삼성증권' },
+	{ value: '243', renderText: '한국투자증권' },
+	{ value: '247', renderText: '우리투자증권' },
+	{ value: '261', renderText: '교보증권' },
+	{ value: '262', renderText: '하이투자증권' },
+	{ value: '263', renderText: 'HMC투자증권' },
+	{ value: '264', renderText: '키움증권' },
+	{ value: '265', renderText: '이베스트투자증권' },
+	{ value: '266', renderText: 'SK증권' },
+	{ value: '267', renderText: '대신증권' },
+	{ value: '268', renderText: '아이엠투자증권' },
+	{ value: '269', renderText: '한화투자증권' },
+	{ value: '270', renderText: '하나대투자증권' },
+	{ value: '279', renderText: '동부증권' },
+	{ value: '280', renderText: '유진투자증권' },
+	{ value: '288', renderText: '카카오페이증권' },
+	{ value: '287', renderText: '메리츠종합금융증권' },
+	{ value: '290', renderText: '부국증권' },
+	{ value: '291', renderText: '신영증권' },
+	{ value: '292', renderText: 'LIG투자증권' },
+	{ value: '271', renderText: '토스증권' },
 ];
 
-const ACTIVATION = ['계좌활성화', '활성화', '비활성화'];
-const STATUS = ['계좌상태', '관리자확인필요', '입금대기', '운용중', '투자중지', '해지'];
+const ACTIVATION = [
+	{ value: 0, renderText: '계좌활성화' },
+	{ value: 'true', renderText: '활성화' },
+	{ value: 'false', renderText: '비활성화' },
+];
+const STATUS = [
+	{ value: 0, renderText: '계좌상태' },
+	{ value: 9999, renderText: '관리자확인필요' },
+	{ value: 1, renderText: '입금대기' },
+	{ value: 2, renderText: '운용중' },
+	{ value: 3, renderText: '투자중지' },
+	{ value: 4, renderText: '해지' },
+];

--- a/client/src/pages/Users/index.tsx
+++ b/client/src/pages/Users/index.tsx
@@ -1,8 +1,9 @@
-import { Layout, Pagenation, UserGridTable } from "@src/components"
+import { DropDown, Layout, Pagenation, SearchInput, UserGridTable } from "@src/components"
 import { getUsers, getUsersByPagenation } from '@src/core/apis/user';
 import { UserResponseDTO } from "@src/types/api";
 import { useQuery } from "@tanstack/react-query"
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 
 const tableHeadTrs = [
 	'고객명',
@@ -18,27 +19,70 @@ const tableHeadTrs = [
 	'',
 ];
 
+const isStaffOptions = [
+	{
+		value: 'true',
+		renderText: '임직원 O',
+	},
+	{
+		value: 'false',
+		renderText: '임직원 X',
+	},
+
+];
+
+const isActiveOptions = [
+	{
+		value: 'true',
+		renderText: '활성화 O',
+	},
+	{
+		value: 'false',
+		renderText: '활성화 X',
+	},
+];
+
 const PAGE_OFFSET = 20;
 const DEFALUT_PAGE = 1;
 
 const Users = () => {
 	const [currentPage, setCurrentPage] = useState(DEFALUT_PAGE);
-	const { data: users } = useQuery<UserResponseDTO[]>(['getUsers'], async () => getUsers());
+	const [searchKeyword, setSearchKeyword] = useState("");
+	const { data: users } = useQuery<UserResponseDTO[]>(['getUsers', searchKeyword], async () => getUsers(searchKeyword || null));
   const { data: currentUsers } = useQuery<UserResponseDTO[]>(['getUsersByPagenation', currentPage], async () =>
 		getUsersByPagenation(currentPage, PAGE_OFFSET),
 	);
-	const totalPage = useMemo(() => users && Math.floor(users.length / PAGE_OFFSET), [users]); 
+	const totalPage = useMemo(() => users && Math.ceil(users.length / PAGE_OFFSET), [users]); 
 
 	const handlePagenationChange = (newPage: number) => {
 		setCurrentPage(newPage);
 	}
+
+	const handleSearchByKeyword = (keyword: string) => {
+		setSearchKeyword(keyword);
+	}
 	
   return (
 		<Layout>
+			<div className="flex justify-between h-10 mb-4">
+				<div className="flex items-center">
+					<Link
+						to="/users/post-user"
+						className="flex items-center h-full rounded bg-[#041527] text-white font-bold px-4 opacity-80 hover:opacity-100"
+					>
+						고객 생성
+					</Link>
+				</div>
+				<div className="flex items-center">
+					<DropDown options={isActiveOptions} />
+					<DropDown options={isStaffOptions} />
+					<SearchInput onSearchByKeyword={handleSearchByKeyword} />
+				</div>
+			</div>
+
 			<UserGridTable
 				tableHeadTrs={tableHeadTrs}
-				tableBodyList={currentUsers}
-				gridCols="[minmax(150px,_1fr)_minmax(120px,_1fr)_minmax(150px,_1fr)_minmax(200px,_1fr)_minmax(150px,_1fr)_minmax(180px,_1fr)_minmax(150px,_1fr)_minmax(150px,_1fr)_minmax(120px,_1fr)_minmax(150px,_1fr)_minmax(120px,_1fr)]"
+				tableBodyList={searchKeyword ? users : currentUsers}
 			/>
 			<Pagenation currentPage={currentPage} totalPage={totalPage ?? DEFALUT_PAGE} onPagenationChange={handlePagenationChange} />
 		</Layout>


### PR DESCRIPTION
## 해결한 이슈

- #13 

  - [x] 고객 생성 버튼 UI 
  - [x] FullText 검색 기능(with. JSON Server)
  - [x] Dropdown 데이터에 따른 필터링
    - `SearchInput`, `Dropdown` 컴포넌트 props 확장되었습니다. 각각 확인하시길 바랍니다. 
    @od-log @forest-6 @hopak-e @jong6598 

<br />

## 해결 방법

`고객 목록 - 검색 기능`

- 기존에 구현된 `SearchInput` 컴포넌트를 확장
  - validation 이 크게 필요하지 않는 부분이라서, 굳이 Controlled 가 아닌 `UnControlled` 컴포넌트 방식으로 input 을 핸들링
  - form 이벤트가 발생했을 때 `inputRef` 의 value 를 뽑아내서 props 로 넘긴 onSubmit 이벤트의 인자로 넘김
  - value 를 받은 이벤트 핸들러에서는 현재 검색어 키워드 state 를 변경
- 기존의 `getUsers` API 함수에 `queryString` 이 있을 경우 포함하도록 확장
- getUsers 에 대한 useQuery 의존성 키 배열에 현재 입력된 키워드 state 를 의존성으로 주입, keyword 가 변경 시, getUsers API 재호출
- UsersGridTable 컴포넌트의 렌더링 데이터는 키워드 state 가 있을 경우는 `검색 결과로 받은 users 서버데이터`를, keyword 가 없는 경우는 `현재 페이지에 해당하는 users 서버데이터`를 사용하도록 분기 처리


## 캡처 첨부

`고객 목록 - 검색 기능`

![full_text_search](https://user-images.githubusercontent.com/50790145/202023273-8a2c370f-2e85-4229-a821-8427e385cef9.gif)


<br />

## 추가적인 태스크

- [x] Dropdown 아이템에 따른 필터링

<br />
<br />

## PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다.
