### PR TITLE
[#15] 페이지네이션 방법 수정

### DIFF
--- a/client/src/components/shared/Pagenation/index.tsx
+++ b/client/src/components/shared/Pagenation/index.tsx
@@ -1,21 +1,50 @@
 import { Button } from '@src/components';
-import { useCallback } from 'react';
+import React, { startTransition, useCallback, useEffect, useState } from 'react';
 
 type Props = {
 	currentPage: number;
 	totalPage: number;
 	onPagenationChange: (newPage: number) => void;
+	setCurrentPage: React.Dispatch<React.SetStateAction<number>>;
+	filterObj: object;
+	searchKeyword: string;
 };
 
 const INITAL_PAGE = 1;
+const PagePerView = 10;
 
 const Pagenation = (props: Props) => {
+	const [startPage, setStartPage] = useState(INITAL_PAGE);
+	const [endPage, setEndPage] = useState(PagePerView);
+
+	useEffect(() => {
+		if (props.totalPage > PagePerView) {
+			setEndPage(PagePerView);
+		} else {
+			setEndPage(props.totalPage);
+		}
+	}, [props.totalPage]);
+
+	useEffect(() => {
+		props.setCurrentPage(INITAL_PAGE);
+		setStartPage(INITAL_PAGE);
+		if (props.totalPage > PagePerView) {
+			setEndPage(PagePerView);
+		} else {
+			setEndPage(props.totalPage);
+		}
+	}, [props.filterObj, props.searchKeyword]);
+
 	const numberArrayGenerator = useCallback(
-		(size: number) =>
-			Array(size)
-				.fill(null)
-				.map((_, index) => index + 1),
-		[props.totalPage],
+		(startPage: number, endPage: number) => {
+			let array = [];
+			for (let i = startPage; i < endPage + 1; i++) {
+				array.push(i);
+			}
+			console.log(array);
+			return array;
+		},
+		[endPage, startPage],
 	);
 
 	const handlePagenationClick = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -28,11 +57,31 @@ const Pagenation = (props: Props) => {
 			<Button
 				type="button"
 				data-page={INITAL_PAGE}
-				className="hover:text-blue-500"
-				onClick={handlePagenationClick}
+				disabled={props.currentPage === 1}
+				className="hover:text-blue-25 disabled:opacity-50"
+				onClick={(e) => {
+					handlePagenationClick(e);
+					setStartPage(INITAL_PAGE);
+					if (props.totalPage < PagePerView) setEndPage(props.totalPage);
+					setEndPage(PagePerView);
+				}}
 			>{`<<`}</Button>
+			<Button
+				type="button"
+				data-page={props.currentPage - 1}
+				disabled={props.currentPage === 1}
+				className="hover:text-blue-500 disabled:opacity-50"
+				onClick={(e) => {
+					handlePagenationClick(e);
+					if (props.currentPage % PagePerView === 1) {
+						setStartPage(props.currentPage - PagePerView);
+						setEndPage(props.currentPage - 1);
+					}
+				}}
+			>{`이전`}</Button>
+
 			<div className="flex items-center mx-4">
-				{numberArrayGenerator(props.totalPage).map((number) => {
+				{numberArrayGenerator(startPage, endPage).map((number) => {
 					return (
 						<Button
 							key={number}
@@ -48,9 +97,32 @@ const Pagenation = (props: Props) => {
 			</div>
 			<Button
 				type="button"
+				data-page={props.currentPage + 1}
+				disabled={props.currentPage === props.totalPage}
+				className="hover:text-blue-500 disabled:opacity-25"
+				onClick={(e) => {
+					handlePagenationClick(e);
+					if (props.currentPage % PagePerView === 0) {
+						setStartPage(startPage + PagePerView);
+						if (props.currentPage + PagePerView > props.totalPage) {
+							setEndPage(props.totalPage);
+						} else {
+							setEndPage(endPage + PagePerView);
+						}
+					}
+				}}
+			>{`다음`}</Button>
+
+			<Button
+				type="button"
 				data-page={props.totalPage}
-				className="hover:text-blue-500"
-				onClick={handlePagenationClick}
+				disabled={props.currentPage === props.totalPage}
+				className="hover:text-blue-500 disabled:opacity-25"
+				onClick={(e) => {
+					handlePagenationClick(e);
+					setEndPage(props.totalPage);
+					setStartPage(props.totalPage - ((props.totalPage % PagePerView) - 1));
+				}}
 			>{`>>`}</Button>
 		</div>
 	);

--- a/client/src/pages/Account/index.tsx
+++ b/client/src/pages/Account/index.tsx
@@ -51,7 +51,14 @@ const Account = () => {
 					<SearchInput onSearchByKeyword={handleSearchByKeyword} />
 				</div>
 				<AccountGrid accountList={accounts} />
-				<Pagenation totalPage={totalPage!} currentPage={currentPage} onPagenationChange={handlePagenationChange} />
+				<Pagenation
+					searchKeyword={searchKeyword}
+					setCurrentPage={setCurrentPage}
+					filterObj={accountFilterObj}
+					totalPage={totalPage!}
+					currentPage={currentPage}
+					onPagenationChange={handlePagenationChange}
+				/>
 			</main>
 		</Layout>
 	);

--- a/client/src/pages/Users/index.tsx
+++ b/client/src/pages/Users/index.tsx
@@ -81,7 +81,7 @@ const Users = () => {
 	});
 
 	const handleDropdownFilterChange = (value: string, changeTarget: string) => {
-		setDropdownObj({ ...dropdownObj, [changeTarget]: value })
+		setDropdownObj({ ...dropdownObj, [changeTarget]: value });
 	};
 
 	return (
@@ -103,7 +103,14 @@ const Users = () => {
 			</div>
 
 			<UserGridTable tableHeadTrs={tableHeadTrs} tableBodyList={searchKeyword ? users : currentUsers} />
-			<Pagenation currentPage={currentPage} totalPage={totalPage ?? DEFALUT_PAGE} onPagenationChange={handlePagenationChange} />
+			<Pagenation
+				searchKeyword={searchKeyword}
+				setCurrentPage={setCurrentPage}
+				filterObj={dropdownObj}
+				currentPage={currentPage}
+				totalPage={totalPage ?? DEFALUT_PAGE}
+				onPagenationChange={handlePagenationChange}
+			/>
 		</Layout>
 	);
 };


### PR DESCRIPTION
## 해결한 이슈

- #15 

<br />

## 해결 방법

`페이지네이션 방법 수정`

- 기존에 전체페이지 수가 다보이던 상태에서 10페이지와 같은 단위로 현재 페이지에 보일 페이지 갯수를 나누는 방식으로 변경

```tsx
	useEffect(() => {
		props.setCurrentPage(INITAL_PAGE);
		setStartPage(INITAL_PAGE);
		if (props.totalPage > PagePerView) {
			setEndPage(PagePerView);
		} else {
			setEndPage(props.totalPage);
		}
	}, [props.filterObj, props.searchKeyword]);
```
- 필터링과 검색 시 새로 토탈 페이지를 계산하고, 처음 페이지로 이동할 수 있게 useEffect의 의존성 배열로 필터객체와 검색어 부여

<br />

## 캡처 첨부

<img width="1440" alt="스크린샷 2022-11-18 오전 5 21 35" src="https://user-images.githubusercontent.com/108744804/202551610-486ebcaf-26ee-4892-9774-e68aa06695cf.png">

<br />

## 추가적인 태스크

- 내용을 입력해주세요.

<br />
<br />

## PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다.
